### PR TITLE
Modificación de nombres de armas de rango

### DIFF
--- a/Core/DefInjected/RecipeDef/ImpliedDefs.xml
+++ b/Core/DefInjected/RecipeDef/ImpliedDefs.xml
@@ -261,26 +261,26 @@
   <!-- EN: Haciendo estómago biónico. -->
   <Make_BionicStomach.jobString>Fabricando estómago biónico.</Make_BionicStomach.jobString>
   
-  <!-- EN: fabricar arco largo -->
-  <Make_Bow_Great.label>construir arco largo</Make_Bow_Great.label>
-  <!-- EN: Fabrica un arco largo. -->
-  <Make_Bow_Great.description>Un potente arco largo. Dispara flechas pesadas a largas distancias.</Make_Bow_Great.description>
-  <!-- EN: Haciendo arco largo. -->
-  <Make_Bow_Great.jobString>Construyendo arco largo.</Make_Bow_Great.jobString>
+  <!-- EN: fabricar arco grande -->
+  <Make_Bow_Great.label>fabricar arco grande</Make_Bow_Great.label>
+  <!-- EN: Fabrica un arco grande. -->
+  <Make_Bow_Great.description>Fabrica un arco grande.</Make_Bow_Great.description>
+  <!-- EN: Haciendo arco grande. -->
+  <Make_Bow_Great.jobString>Fabricando arco grande.</Make_Bow_Great.jobString>
   
   <!-- EN: fabricar arco recurvo -->
-  <Make_Bow_Recurve.label>construir arco recurvo</Make_Bow_Recurve.label>
+  <Make_Bow_Recurve.label>fabricar arco recurvo</Make_Bow_Recurve.label>
   <!-- EN: Fabrica un arco recurvo. -->
-  <Make_Bow_Recurve.description>Un arco recurvo avanzado. Su construcción comprende un resorte sintonizado, almacenando energía más eficientemente y permitiendo un tiro más rápido.</Make_Bow_Recurve.description>
+  <Make_Bow_Recurve.description>Fabrica un arco recurvo.</Make_Bow_Recurve.description>
   <!-- EN: Haciendo arco recurvo. -->
-  <Make_Bow_Recurve.jobString>Construyendo arco recurvo.</Make_Bow_Recurve.jobString>
+  <Make_Bow_Recurve.jobString>Fabricando arco recurvo.</Make_Bow_Recurve.jobString>
   
   <!-- EN: fabricar arco corto -->
-  <Make_Bow_Short.label>construir arco corto</Make_Bow_Short.label>
+  <Make_Bow_Short.label>fabricar arco corto</Make_Bow_Short.label>
   <!-- EN: Fabrica un arco corto. -->
-  <Make_Bow_Short.description>Un sencillo arco corto, elaborado con destreza pero usando solamente la tecnología más primitiva.</Make_Bow_Short.description>
+  <Make_Bow_Short.description>Fabrica un arco corto.</Make_Bow_Short.description>
   <!-- EN: Haciendo arco corto. -->
-  <Make_Bow_Short.jobString>Construyendo arco corto.</Make_Bow_Short.jobString>
+  <Make_Bow_Short.jobString>Fabricando arco corto.</Make_Bow_Short.jobString>
   
   <!-- EN: fabricar implante auditivo -->
   <Make_CochlearImplant.label>fabricar implante auditivo</Make_CochlearImplant.label>
@@ -332,18 +332,18 @@
   <Make_Gun_ChainShotgun.jobString>Fabricando escopeta automática.</Make_Gun_ChainShotgun.jobString>
   
   <!-- EN: fabricar lanza de cargas -->
-  <Make_Gun_ChargeLance.label>fabricar cañón de riel</Make_Gun_ChargeLance.label>
+  <Make_Gun_ChargeLance.label>fabricar lanza de cargas</Make_Gun_ChargeLance.label>
   <!-- EN: Fabrica un lanza de cargas. -->
-  <Make_Gun_ChargeLance.description>Arma lanzadora de cargas eléctricas asistida por un riel. Dispara una única carga a alta velocidad.</Make_Gun_ChargeLance.description>
+  <Make_Gun_ChargeLance.description>Fabrica una lanza de cargas.</Make_Gun_ChargeLance.description>
   <!-- EN: Haciendo lanza de cargas. -->
-  <Make_Gun_ChargeLance.jobString>Fabricando cañón de riel.</Make_Gun_ChargeLance.jobString>
+  <Make_Gun_ChargeLance.jobString>Fabricando lanza de cargas.</Make_Gun_ChargeLance.jobString>
   
-  <!-- EN: fabricar rifle de cargas R-4 -->
-  <Make_Gun_ChargeRifle.label>fabricar rifle de cargas R-4</Make_Gun_ChargeRifle.label>
-  <!-- EN: Fabrica un rifle de cargas R-4. -->
-  <Make_Gun_ChargeRifle.description>Un rifle de asalto que dispara pulsos de energía. Esta tecnología carga cada disparo con energía inestable al salir del cañón. La energía liberada al impactar incrementa enormemente el daño causado.</Make_Gun_ChargeRifle.description>
-  <!-- EN: Haciendo rifle de cargas R-4. -->
-  <Make_Gun_ChargeRifle.jobString>Fabricando rifle de cargas R-4.</Make_Gun_ChargeRifle.jobString>
+  <!-- EN: fabricar fusil de cargas -->
+  <Make_Gun_ChargeRifle.label>fabricar fusil de cargas</Make_Gun_ChargeRifle.label>
+  <!-- EN: Fabrica un fusil de cargas. -->
+  <Make_Gun_ChargeRifle.description>Fabrica un fusil de cargas.</Make_Gun_ChargeRifle.description>
+  <!-- EN: Haciendo fusil de cargas. -->
+  <Make_Gun_ChargeRifle.jobString>Fabricando fusil de cargas.</Make_Gun_ChargeRifle.jobString>
   
   <!-- EN: fabricar subfusil pesado -->
   <Make_Gun_HeavySMG.label>fabricar subfusil pesado</Make_Gun_HeavySMG.label>
@@ -464,12 +464,12 @@
   <!-- EN: Haciendo penoxicilina. -->
   <Make_Penoxycyline.jobString>Produciendo penoxicilina.</Make_Penoxycyline.jobString>
   
-  <!-- EN: fabricar jabalinas -->
-  <Make_Pila.label>forjar jabalinas</Make_Pila.label>
-  <!-- EN: Fabrica un jabalinas. -->
-  <Make_Pila.description>Un manojo de jabalinas, lanzas arrojadizas reutilizables. Se tardan mucho en lanzar, pero un impacto provoca gran daño.</Make_Pila.description>
-  <!-- EN: Haciendo jabalinas. -->
-  <Make_Pila.jobString>Fabricando jabalinas.</Make_Pila.jobString>
+  <!-- EN: fabricar pila -->
+  <Make_Pila.label>forjar pila</Make_Pila.label>
+  <!-- EN: Fabrica un pila. -->
+  <Make_Pila.description>Forja unas pila.</Make_Pila.description>
+  <!-- EN: Haciendo pila. -->
+  <Make_Pila.jobString>Forjando pila.</Make_Pila.jobString>
   
   <!-- EN: fabricar té psicoide -->
   <Make_PsychiteTea.label>preparar té psicoide</Make_PsychiteTea.label>

--- a/Core/DefInjected/ThingDef/RangedIndustrialConsumable.xml
+++ b/Core/DefInjected/ThingDef/RangedIndustrialConsumable.xml
@@ -2,27 +2,27 @@
 <LanguageData>
   
   <!-- EN: doomsday rocket -->
-  <Bullet_DoomsdayRocket.label>misil apocalíptico</Bullet_DoomsdayRocket.label>
+  <Bullet_DoomsdayRocket.label>cohete apocalíptico</Bullet_DoomsdayRocket.label>
   
   <!-- EN: rocket -->
-  <Bullet_Rocket.label>misil</Bullet_Rocket.label>
+  <Bullet_Rocket.label>cohete</Bullet_Rocket.label>
   
   <!-- EN: doomsday rocket launcher -->
-  <Gun_DoomsdayRocket.label>lanzamisiles apocalíptico</Gun_DoomsdayRocket.label>
+  <Gun_DoomsdayRocket.label>lanzacohetes apocalíptico</Gun_DoomsdayRocket.label>
   <!-- EN: A single-use rocket launcher that fires a massive explosive projectile. Good against large groups of soft targets. Starts fires.\n\nBecause of its unwieldiness, single-use limitation, and the massive destruction it causes, it's said that one must be slightly crazy to use this weapon. -->
   <Gun_DoomsdayRocket.description>Un lanzacohetes de un solo uso que dispara un proyectil explosivo de gran envergadura. Bueno contra grandes grupos de objetivos débiles. Provoca incendios.\n\nDebido a su incomodidad, a su único disparo y a la destrucción masiva que causa, se dice que uno debe estar un poco loco para usar esta arma.</Gun_DoomsdayRocket.description>
   <!-- EN: barrel -->
   <Gun_DoomsdayRocket.tools.barrel.label>cañón</Gun_DoomsdayRocket.tools.barrel.label>
   <!-- EN: doomsday rocket launcher -->
-  <Gun_DoomsdayRocket.verbs.Verb_ShootOneUse.label>lanzamisiles apocalíptico</Gun_DoomsdayRocket.verbs.Verb_ShootOneUse.label>
+  <Gun_DoomsdayRocket.verbs.Verb_ShootOneUse.label>lanzacohetes apocalíptico</Gun_DoomsdayRocket.verbs.Verb_ShootOneUse.label>
   
   <!-- EN: triple rocket launcher -->
-  <Gun_TripleRocket.label>lanzamisiles triple</Gun_TripleRocket.label>
+  <Gun_TripleRocket.label>lanzacohetes triple</Gun_TripleRocket.label>
   <!-- EN: A single-use rocket launcher that fires three large-bore explosive rockets. Good against small groups of tough targets.\n\nBecause of its unwieldiness, single-use limitation, and the massive destruction it causes, it's said that one must be slightly crazy to use this weapon. -->
-  <Gun_TripleRocket.description>Un lanzacohetes de un solo uso que dispara un grupo de tres misiles explosivos de gran calibre. Bueno contra grupos pequeños de objetivos duros.\n\nDebido a su incomodidad, a su único disparo y a la destrucción masiva que causa, se dice que uno debe estar un poco loco para usar esta arma.</Gun_TripleRocket.description>
+  <Gun_TripleRocket.description>Un lanzacohetes de un solo uso que dispara un grupo de tres cohetes explosivos de gran calibre. Bueno contra grupos pequeños de objetivos duros.\n\nDebido a su incomodidad, a su único disparo y a la destrucción masiva que causa, se dice que uno debe estar un poco loco para usar esta arma.</Gun_TripleRocket.description>
   <!-- EN: barrel -->
   <Gun_TripleRocket.tools.barrel.label>cañón</Gun_TripleRocket.tools.barrel.label>
   <!-- EN: triple rocket launcher -->
-  <Gun_TripleRocket.verbs.Verb_ShootOneUse.label>lanzamisiles triple</Gun_TripleRocket.verbs.Verb_ShootOneUse.label>
+  <Gun_TripleRocket.verbs.Verb_ShootOneUse.label>lanzacohetes triple</Gun_TripleRocket.verbs.Verb_ShootOneUse.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThingDef/RangedNeolithic.xml
+++ b/Core/DefInjected/ThingDef/RangedNeolithic.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: greatbow arrow -->
-  <Arrow_Great.label>flecha de arco largo</Arrow_Great.label>
+  <Arrow_Great.label>flecha de arco grande</Arrow_Great.label>
   
   <!-- EN: recurve bow arrow -->
   <Arrow_Recurve.label>flecha de arco recurvo</Arrow_Recurve.label>
@@ -11,20 +11,20 @@
   <Arrow_Short.label>flecha de arco corto</Arrow_Short.label>
   
   <!-- EN: greatbow -->
-  <Bow_Great.label>arco largo</Bow_Great.label>
+  <Bow_Great.label>arco grande</Bow_Great.label>
   <!-- EN: A powerful greatbow. Fires a heavy arrow long distances. -->
-  <Bow_Great.description>Un potente arco largo. Dispara flechas pesadas a largas distancias.</Bow_Great.description>
+  <Bow_Great.description>Un gran y potente arco. Dispara flechas pesadas a largas distancias.</Bow_Great.description>
   <!-- EN: limb -->
-  <Bow_Great.tools.limb.label>extremidad</Bow_Great.tools.limb.label>
+  <Bow_Great.tools.limb.label>rama</Bow_Great.tools.limb.label>
   <!-- EN: greatbow -->
-  <Bow_Great.verbs.Verb_Shoot.label>arco largo</Bow_Great.verbs.Verb_Shoot.label>
+  <Bow_Great.verbs.Verb_Shoot.label>arco grande</Bow_Great.verbs.Verb_Shoot.label>
   
   <!-- EN: recurve bow -->
   <Bow_Recurve.label>arco recurvo</Bow_Recurve.label>
   <!-- EN: A recurve bow. Its construction behaves like a tuned spring, storing energy more efficiently and delivering a faster shot. -->
   <Bow_Recurve.description>Un arco recurvo avanzado. Su construcción permite un resorte sintonizado, almacenando energía más eficientemente y liberando un tiro más rápido.</Bow_Recurve.description>
   <!-- EN: limb -->
-  <Bow_Recurve.tools.limb.label>extremidad</Bow_Recurve.tools.limb.label>
+  <Bow_Recurve.tools.limb.label>rama</Bow_Recurve.tools.limb.label>
   <!-- EN: recurve bow -->
   <Bow_Recurve.verbs.Verb_Shoot.label>arco recurvo</Bow_Recurve.verbs.Verb_Shoot.label>
   
@@ -33,22 +33,22 @@
   <!-- EN: A simple short selfbow made from a single piece of wood. -->
   <Bow_Short.description>Un sencillo arco corto, elaborado con una sola pieza de madera.</Bow_Short.description>
   <!-- EN: limb -->
-  <Bow_Short.tools.limb.label>extremidad</Bow_Short.tools.limb.label>
+  <Bow_Short.tools.limb.label>rama</Bow_Short.tools.limb.label>
   <!-- EN: short bow -->
   <Bow_Short.verbs.Verb_Shoot.label>arco corto</Bow_Short.verbs.Verb_Shoot.label>
   
   <!-- EN: pila -->
-  <Pila.label>jabalinas</Pila.label>
+  <Pila.label>pila</Pila.label>
   <!-- EN: Pila are spears for throwing. They take a long time to throw, but one hit can do heavy damage. This weapon represents a bundle of pila and can be thrown over and over. The singular of pila is pilum. -->
-  <Pila.description>Son lanzas arrojadizas. Tardan mucho tiempo en lanzarse, pero un impacto puede causar mucho daño. Este arma representa un manojo de jabalinas y pueden ser lanzadas una y otra vez.</Pila.description>
+  <Pila.description>El pilum (en plural pila) son lanzas para arrojar. Tardan mucho tiempo en lanzarse, pero un golpe puede causar mucho daño. Esta arma representa un paquete de pila para arrojar y pueden ser lanzadas una y otra vez.</Pila.description>
   <!-- EN: shaft -->
   <Pila.tools.shaft.label>ástil</Pila.tools.shaft.label>
   <!-- EN: point -->
   <Pila.tools.point.label>punta</Pila.tools.point.label>
   <!-- EN: pila -->
-  <Pila.verbs.Verb_Shoot.label>jabalinas</Pila.verbs.Verb_Shoot.label>
+  <Pila.verbs.Verb_Shoot.label>pila</Pila.verbs.Verb_Shoot.label>
   
   <!-- EN: pilum -->
-  <Pilum_Thrown.label>jabalina</Pilum_Thrown.label>
+  <Pilum_Thrown.label>pilum</Pilum_Thrown.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThingDef/RangedSpacer.xml
+++ b/Core/DefInjected/ThingDef/RangedSpacer.xml
@@ -2,10 +2,10 @@
 <LanguageData>
   
   <!-- EN: charge lance shot -->
-  <Bullet_ChargeLance.label>carga de energía</Bullet_ChargeLance.label>
+  <Bullet_ChargeLance.label>disparo de lanza de cargas</Bullet_ChargeLance.label>
   
   <!-- EN: charge shot -->
-  <Bullet_ChargeRifle.label>carga de energía</Bullet_ChargeRifle.label>
+  <Bullet_ChargeRifle.label>disparo de cargas</Bullet_ChargeRifle.label>
   
   <!-- EN: charge lance -->
   <Gun_ChargeLance.label>lanza de cargas</Gun_ChargeLance.label>
@@ -17,14 +17,14 @@
   <Gun_ChargeLance.verbs.Verb_Shoot.label>lanza de cargas</Gun_ChargeLance.verbs.Verb_Shoot.label>
   
   <!-- EN: charge rifle -->
-  <Gun_ChargeRifle.label>rifle de cargas R-4</Gun_ChargeRifle.label>
+  <Gun_ChargeRifle.label>fusil de cargas</Gun_ChargeRifle.label>
   <!-- EN: A charged-shot assault rifle. Pulse-charge technology charges each shot with unstable energy as it leaves the barrel. Released on impact, the charged energy greatly increases the damage done. -->
-  <Gun_ChargeRifle.description>Rifle de asalto que dispara cargas de energía. La tecnología de pulsos carga cada disparo con energía inestable al salir del cañón. Gran potencia.</Gun_ChargeRifle.description>
+  <Gun_ChargeRifle.description>Un fusil de asalto que dispara cargas de energía. La tecnología de pulsos carga cada disparo con energía inestable al salir del cañón. La energía cargada se libera en el momento del impacto y aumenta enormemente el daño causado.</Gun_ChargeRifle.description>
   <!-- EN: stock -->
   <Gun_ChargeRifle.tools.stock.label>culata</Gun_ChargeRifle.tools.stock.label>
   <!-- EN: barrel -->
   <Gun_ChargeRifle.tools.barrel.label>cañón</Gun_ChargeRifle.tools.barrel.label>
   <!-- EN: charge rifle -->
-  <Gun_ChargeRifle.verbs.Verb_Shoot.label>rifle de cargas R-4</Gun_ChargeRifle.verbs.Verb_Shoot.label>
+  <Gun_ChargeRifle.verbs.Verb_Shoot.label>fusil de cargas</Gun_ChargeRifle.verbs.Verb_Shoot.label>
   
 </LanguageData>


### PR DESCRIPTION
He modificado algunos nombres, especialmente aquellos con añadidos extraños como el rifle de cargas R-4, también quiero modificar la palabra rifle por fusil en todas las armas y mantener el mismo lore, con el subfusil como hice en la traducción latina, esto ayuda a la hora de traducir mods porque se maneja un solo nombre y al traducir una versión se copia y se mantienen pocos cambios.